### PR TITLE
Fix some README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Lolcate is a fast, lightweight, versatile alternative to [locate / mlocate / upd
 It features:
 
 - **indexing rules** allowing you to easily specify which path names to index and which ones to prune ;
-- powerful, UTF8-compilant **querying rules** ;
-- the abitily to create **multiple databases** for multiple purposes.
+- powerful, UTF8-compliant **querying rules** ;
+- the ability to create **multiple databases** for multiple purposes.
 
 Lolcate comes as a single binary executable.
 


### PR DESCRIPTION
On a side note, the comment for the "ignore_hidden" configuration specifies opposite semantics from the name, but I don't know which one is correct.