### PR TITLE
Add support for Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ bstr = "0.2"
 clap = "2"
 crossbeam-channel = "0.4"
 dirs = "2.0"
-expanduser = "1.2"
 ignore = "0.4"
 lazy_static = "1.4.0"
 lz4 = "1"
@@ -31,6 +30,9 @@ serde = { version = "1.0", features = ["derive"] }
 termcolor = "1"
 toml = "0.5"
 walkdir = "2"
+
+[target.'cfg(not(windows))'.dependencies]
+expanduser = "1.2"
 
 [[bin]]
 path = "src/main.rs"

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,7 +89,12 @@ mod deserialize {
     {
         let s = Vec::<String>::deserialize(deserializer)?;
         s.into_iter()
-            .map(|s| expanduser::expanduser(&s).map_err(serde::de::Error::custom))
+            .map(|s| {
+                #[cfg(not(windows))]
+                return expanduser::expanduser(&s).map_err(serde::de::Error::custom);
+                #[cfg(windows)]
+                return Ok(s.into());
+            })
             .collect()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ pub fn lolcate_config_path() -> PathBuf {
 }
 
 pub fn lolcate_data_path() -> PathBuf {
-    let mut path = dirs::data_dir().unwrap();
+    let mut path = dirs::data_local_dir().unwrap();
     path.push("lolcate");
     path
 }


### PR DESCRIPTION
Only thing preventing it from working was the unconditional use of `expanduser`, but Windows doesn't need to expand `~`. Create/update DB and search works for me on Windows after this patch.

Also stores the DB in local AppData rather than roaming. My understanding is that this is more correct in the case of roaming user profiles: "Windows uses the Local and LocalLow folders for application data that does not roam with the user. Usually this data is either machine specific or too large to roam."

I'm not entirely sure where the config files are stored is correct in the case of roaming profiles, but I didn't want to break the behavior of non-Windows systems/add more conditional compilation logic. I'm also not a Windows enterprise admin.

Behavior unchanged for non-Windows systems. `data_local_dir()` is the same place as `data_dir()` on Linux and Mac.