### PR TITLE
Do not write entries if path contains newline

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -341,9 +341,10 @@ fn update_database(db_name: &str) -> std::io::Result<()> {
             .build(output_fn)?;
         for entry in rx {
             match entry.path().to_str() {
-                Some(s) => {
+                Some(s) if !s.contains('\n') => {
                     writeln!(encoder, "{}", s).unwrap();
                 }
+                Some(_) => eprintln!("File name contains newline: {:?}", entry.path()),
                 _ => eprintln!("File name contains invalid unicode: {:?}", entry.path()),
             }
         }


### PR DESCRIPTION
Newlines are valid in filenames on at least most Nix systems, but lolcate expects the db to be 1 line = 1 entry